### PR TITLE
catkin_simple: 0.1.2-5 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6,5 +6,16 @@ release_platforms:
   ubuntu:
   - trusty
 repositories:
+  catkin_simple:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/catkin_simple-release.git
+      version: 0.1.2-5
+    source:
+      type: git
+      url: https://github.com/zurich-eye/catkin_simple.git
+      version: master
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_simple` to `0.1.2-5`:

- upstream repository: https://github.com/zurich-eye/catkin_simple.git
- release repository: https://github.com/zurich-eye/catkin_simple-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
