### PR TITLE
cmake_external_project_catkin: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -17,5 +17,16 @@ repositories:
       url: https://github.com/zurich-eye/catkin_simple.git
       version: master
     status: maintained
+  cmake_external_project_catkin:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/cmake_external_project_catkin-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/zurich-eye/cmake_external_project_catkin.git
+      version: master
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_external_project_catkin` to `1.0.0-0`:

- upstream repository: https://github.com/zurich-eye/cmake_external_project_catkin.git
- release repository: https://github.com/zurich-eye/cmake_external_project_catkin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
