### PR TITLE
gflags_catkin: 0.1.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -28,5 +28,16 @@ repositories:
       url: https://github.com/zurich-eye/cmake_external_project_catkin.git
       version: master
     status: maintained
+  gflags_catkin:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/gflags_catkin-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/zurich-eye/gflags_catkin.git
+      version: master
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `gflags_catkin` to `0.1.1-0`:

- upstream repository: https://github.com/zurich-eye/gflags_catkin.git
- release repository: https://github.com/zurich-eye/gflags_catkin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
