### PR TITLE
fast_neon: 0.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -28,6 +28,19 @@ repositories:
       url: https://github.com/zurich-eye/cmake_external_project_catkin.git
       version: master
     status: maintained
+  fast_neon:
+    release:
+      packages:
+      - fast
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/fast_neon-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/zurich-eye/fast_neon.git
+      version: 0.0.1
+    status: maintained
   gflags_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fast_neon` to `0.0.1-0`:

- upstream repository: https://github.com/zurich-eye/fast_neon.git
- release repository: https://github.com/zurich-eye/fast_neon-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
