### PR TITLE
glog_catkin: 0.1.2-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -52,5 +52,16 @@ repositories:
       url: https://github.com/zurich-eye/gflags_catkin.git
       version: master
     status: maintained
+  glog_catkin:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: git@github.com:zurich-eye/glog_catkin-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: git@github.com:zurich-eye/glog_catkin.git
+      version: master
+    status: maintained
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `glog_catkin` to `0.1.2-1`:

- upstream repository: git@github.com:zurich-eye/glog_catkin.git
- release repository: git@github.com:zurich-eye/glog_catkin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
