### PR TITLE
visensor_node: 1.7.4-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -70,5 +70,15 @@ repositories:
       url: git@github.com:zurich-eye/libvisensor_devel-release.git
       version: 2.5.7-0
     status: developed
+  visensor_node:
+    release:
+      packages:
+      - visensor_msgs
+      - visensor_node
+      tags:
+        release: release/jade/{package}/{version}
+      url: git@github.com:zurich-eye/visensor_node_devel-release.git
+      version: 1.7.4-0
+    status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `visensor_node` to `1.7.4-0`:

- upstream repository: git@github.com:zurich-eye/visensor_node_devel.git
- release repository: git@github.com:zurich-eye/visensor_node_devel-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
