### PR TITLE
fast: 0.0.1-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -28,6 +28,17 @@ repositories:
       url: https://github.com/zurich-eye/cmake_external_project_catkin.git
       version: master
     status: maintained
+  fast:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: git@github.com:zurich-eye/ze_buildfarm_releases.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: git@github.com:zurich-eye/fast_neon.git
+      version: master
+    status: maintained
   gflags_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fast` to `0.0.1-1`:

- upstream repository: git@github.com:zurich-eye/fast_neon.git
- release repository: git@github.com:zurich-eye/ze_buildfarm_releases.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
