### PR TITLE
gflags: 2.1.2-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -39,6 +39,13 @@ repositories:
       url: git@github.com:zurich-eye/fast_neon.git
       version: master
     status: maintained
+  gflags:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/gflags-release.git
+      version: 2.1.2-2
+    status: maintained
   gflags_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gflags` to `2.1.2-2`:

- upstream repository: https://github.com/gflags/gflags.git
- release repository: https://github.com/zurich-eye/gflags-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
