### PR TITLE
gflags: 2.1.2-3 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -44,7 +44,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/zurich-eye/gflags-release.git
-      version: 2.1.2-2
+      version: 2.1.2-3
+    source:
+      type: git
+      url: https://github.com/gflags/gflags.git
+      version: master
     status: maintained
   libvisensor:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `gflags` to `2.1.2-3`:

- upstream repository: https://github.com/gflags/gflags.git
- release repository: https://github.com/zurich-eye/gflags-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.1.2-2`
