### PR TITLE
glog: 0.4.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -50,6 +50,12 @@ repositories:
       url: https://github.com/gflags/gflags.git
       version: master
     status: maintained
+  glog:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/glog-release.git
+      version: 0.4.0-1
   libvisensor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `glog` to `0.4.0-1`:

- upstream repository: https://github.com/zurich-eye/glog.git
- release repository: https://github.com/zurich-eye/glog-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
