### PR TITLE
gflags: 2.1.2-6 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -44,7 +44,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/zurich-eye/gflags-release.git
-      version: 2.1.2-5
+      version: 2.1.2-6
     source:
       type: git
       url: https://github.com/gflags/gflags.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gflags` to `2.1.2-6`:

- upstream repository: https://github.com/gflags/gflags.git
- release repository: https://github.com/zurich-eye/gflags-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `2.1.2-5`
