### PR TITLE
visensor_node: 1.8.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -54,7 +54,11 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: git@github.com:zurich-eye/visensor_node_devel-release.git
-      version: 1.7.6-0
+      version: 1.8.0-0
+    source:
+      type: git
+      url: git@github.com:zurich-eye/visensor_node_devel.git
+      version: master
     status: developed
 type: distribution
 version: 1


### PR DESCRIPTION
Increasing version of package(s) in repository `visensor_node` to `1.8.0-0`:

- upstream repository: git@github.com:zurich-eye/visensor_node_devel.git
- release repository: git@github.com:zurich-eye/visensor_node_devel-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.7.6-0`
