### PR TITLE
libvisensor: 2.6.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -45,7 +45,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: git@github.com:zurich-eye/libvisensor_devel-release.git
-      version: 2.6.0-0
+      version: 2.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libvisensor` to `2.6.1-0`:

- upstream repository: git@github.com:zurich-eye/libvisensor_devel.git
- release repository: git@github.com:zurich-eye/libvisensor_devel-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.6.0-0`
