### PR TITLE
catkin_simple: 0.1.2-8 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -12,7 +12,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/zurich-eye/catkin_simple-release.git
-      version: 0.1.2-7
+      version: 0.1.2-8
     source:
       type: git
       url: https://github.com/zurich-eye/catkin_simple.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_simple` to `0.1.2-8`:

- upstream repository: https://github.com/zurich-eye/catkin_simple.git
- release repository: https://github.com/zurich-eye/catkin_simple-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.2-7`
