### PR TITLE
fast: 0.0.1-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -34,7 +34,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: git@github.com:zurich-eye/ze_buildfarm_releases.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: git@github.com:zurich-eye/fast_neon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fast` to `0.0.1-2`:

- upstream repository: git@github.com:zurich-eye/fast_neon.git
- release repository: git@github.com:zurich-eye/ze_buildfarm_releases.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.1-1`
