### PR TITLE
cmake_external_project_catkin: 1.0.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -23,7 +23,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/zurich-eye/cmake_external_project_catkin-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/zurich-eye/cmake_external_project_catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_external_project_catkin` to `1.0.0-1`:

- upstream repository: https://github.com/zurich-eye/cmake_external_project_catkin.git
- release repository: https://github.com/zurich-eye/cmake_external_project_catkin-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.0-0`
