### PR TITLE
gflags: 2.1.2-5 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -45,7 +45,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/zurich-eye/gflags-release.git
-      version: 2.1.2-3
+      version: 2.1.2-5
     source:
       type: git
       url: https://github.com/gflags/gflags.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gflags` to `2.1.2-5`:

- upstream repository: https://github.com/gflags/gflags.git
- release repository: https://github.com/zurich-eye/gflags-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `2.1.2-3`
