### PR TITLE
glog: 0.4.0-2 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -50,6 +50,16 @@ repositories:
       type: git
       url: https://github.com/gflags/gflags.git
       version: master
+  glog:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/glog-release.git
+      version: 0.4.0-2
+    source:
+      type: git
+      url: https://github.com/zurich-eye/glog.git
+      version: master
   libvisensor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `glog` to `0.4.0-2`:

- upstream repository: https://github.com/zurich-eye/glog.git
- release repository: https://github.com/zurich-eye/glog-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
