### PR TITLE
glog: 0.4.0-6 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -55,7 +55,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/zurich-eye/glog-release.git
-      version: 0.4.0-5
+      version: 0.4.0-6
     source:
       type: git
       url: https://github.com/zurich-eye/glog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `glog` to `0.4.0-6`:

- upstream repository: https://github.com/zurich-eye/glog.git
- release repository: https://github.com/zurich-eye/glog-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.4.0-5`
