### PR TITLE
dlib: 0.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -29,6 +29,16 @@ repositories:
       url: https://github.com/zurich-eye/cmake_external_project_catkin.git
       version: master
     status: maintained
+  dlib:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/dlib-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/zurich-eye/DLib.git
+      version: master
   fast:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dlib` to `0.0.1-0`:

- upstream repository: https://github.com/zurich-eye/DLib.git
- release repository: https://github.com/zurich-eye/dlib-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
