### PR TITLE
ze_ros_msg: 1.0.0-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -28,5 +28,16 @@ repositories:
       url: https://github.com/zurich-eye/cmake_external_project_catkin.git
       version: master
     status: maintained
+  ze_ros_msg:
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/zurich-eye/ze_ros_msg-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/zurich-eye/ze_ros_msg.git
+      version: master
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ze_ros_msg` to `1.0.0-0`:

- upstream repository: https://github.com/zurich-eye/ze_ros_msg.git
- release repository: https://github.com/zurich-eye/ze_ros_msg-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
