### PR TITLE
ze_ros_msg: 1.0.1-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -33,7 +33,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/zurich-eye/ze_ros_msg-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/zurich-eye/ze_ros_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ze_ros_msg` to `1.0.1-0`:

- upstream repository: https://github.com/zurich-eye/ze_ros_msg.git
- release repository: https://github.com/zurich-eye/ze_ros_msg-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `1.0.0-0`

## ze_ros_msg

- No changes
